### PR TITLE
Add FastAPI backend and Expo mobile app for Seara 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+.env
+.venv/
+.env.local
+node_modules/
+.expo/
+.DS_Store
+.expo-shared/
+.dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# seara2026
+# Seara 2026
+
+Projeto completo (API + aplicativo móvel) para gerenciamento e divulgação do encontro Seara 2026.
+
+## Estrutura do repositório
+
+- `backend/`: API FastAPI com autenticação de administradores, gerenciamento de programação, alertas e horários de confissão.
+- `mobile/`: Aplicativo React Native (Expo) consumindo a API e oferecendo experiência pública e administrativa.
+
+## Como executar localmente
+
+### API
+Consulte o arquivo [`backend/README.md`](backend/README.md) para detalhes de configuração. A API expõe documentação em `/docs` e gera alertas automáticos 10 minutos antes de cada evento.
+
+### Aplicativo mobile
+
+1. Instale as dependências:
+
+```bash
+cd mobile
+npm install
+```
+
+2. Defina a URL da API (opcional). Por padrão o app usa `http://localhost:8000`. Para personalizar, crie um arquivo `.env` na pasta `mobile` com:
+
+```
+EXPO_PUBLIC_API_URL=http://192.168.0.10:8000
+```
+
+3. Inicie o projeto Expo:
+
+```bash
+npm run start
+```
+
+Utilize o aplicativo Expo Go para testar em dispositivos físicos ou um emulador Android/iOS.
+
+## Publicação
+
+- Android: configure o `android.package` em `mobile/app.json` e gere builds via `eas build --platform android`. Siga o guia da Expo para assinatura e publicação na Play Store.
+- iOS: ajuste `ios.bundleIdentifier` e gere builds com `eas build --platform ios`, utilizando uma conta Apple Developer.
+
+Certifique-se de configurar chaves push (FCM/APNS) no backend para envio real de notificações push. Atualmente o backend registra alertas enviados via logs/console, servindo como ponto de extensão para integrações futuras.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,42 @@
+# Seara 2026 API
+
+API construída com FastAPI para atender aos requisitos administrativos do aplicativo Seara 2026.
+
+## Configuração
+
+1. Crie um ambiente virtual e instale as dependências:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Defina variáveis de ambiente (opcional) para criar o primeiro usuário administrador automaticamente:
+
+```bash
+export SEARA_ADMIN_EMAIL=admin@seara2026.com
+export SEARA_ADMIN_PASSWORD=senha-super-segura
+export JWT_SECRET_KEY=uma-chave-secreta
+```
+
+3. Execute a API:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+A API será disponibilizada em `http://127.0.0.1:8000`. A documentação automática pode ser acessada em `/docs`.
+
+## Endpoints principais
+
+- `POST /auth/login`: autenticação de administradores.
+- `POST /auth/users`: criação de novos usuários administradores (requer login).
+- `GET /public/events`: lista de eventos públicos.
+- `GET /public/confessions`: horários de confissão.
+- `GET /public/alerts`: alertas agendados.
+- `POST /admin/events`: cadastro de eventos.
+- `POST /admin/alerts`: cadastro de alertas manuais.
+- `POST /admin/confessions`: cadastro de horários de confissão.
+
+Alertas automáticos são gerados 10 minutos antes do início de cada evento cadastrado.

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from .config import get_settings
+from .database import SessionLocal
+from .models import User
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+settings = get_settings()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.access_token_expire_minutes))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    return encoded_jwt
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Credenciais inválidas",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        email: str = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+    except JWTError as exc:  # pragma: no cover - defensive programming
+        raise credentials_exception from exc
+
+    user: Optional[User] = db.query(User).filter(User.email == email).first()
+    if user is None:
+        raise credentials_exception
+    if not user.is_active:
+        raise HTTPException(status_code=400, detail="Usuário inativo")
+    return user

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,26 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    app_name: str = "Seara 2026 API"
+    debug: bool = False
+    database_url: str = Field(default="sqlite:///" + str(Path(__file__).resolve().parent.parent / "seara.db"))
+    jwt_secret_key: str = Field(default="change-me", env="JWT_SECRET_KEY")
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 60 * 12
+    admin_email: Optional[str] = Field(default=None, env="SEARA_ADMIN_EMAIL")
+    admin_password: Optional[str] = Field(default=None, env="SEARA_ADMIN_PASSWORD")
+    cors_origins: list[str] = Field(default_factory=lambda: ["*"])
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,0 +1,111 @@
+from datetime import datetime, timedelta
+from typing import Iterable, Optional
+
+from sqlalchemy.orm import Session
+
+from . import schemas
+from .auth import get_password_hash
+from .models import Alert, ConfessionSlot, Event, User
+
+
+def get_user_by_email(db: Session, email: str) -> Optional[User]:
+    return db.query(User).filter(User.email == email).first()
+
+
+def create_user(db: Session, user_in: schemas.UserCreate) -> User:
+    db_user = User(email=user_in.email, password_hash=get_password_hash(user_in.password))
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def create_event(db: Session, event_in: schemas.EventCreate) -> Event:
+    event = Event(**event_in.dict())
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    ensure_auto_alert_for_event(db, event)
+    db.refresh(event)
+    return event
+
+
+def update_event(db: Session, event: Event, event_in: schemas.EventUpdate) -> Event:
+    data = event_in.dict(exclude_unset=True)
+    for key, value in data.items():
+        setattr(event, key, value)
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    ensure_auto_alert_for_event(db, event)
+    db.refresh(event)
+    return event
+
+
+def delete_event(db: Session, event: Event) -> None:
+    db.delete(event)
+    db.commit()
+
+
+def ensure_auto_alert_for_event(db: Session, event: Event) -> Optional[Alert]:
+    auto_alert: Optional[Alert] = (
+        db.query(Alert)
+        .filter(Alert.event_id == event.id, Alert.is_auto.is_(True))
+        .first()
+    )
+    scheduled_for = event.starts_at - timedelta(minutes=10)
+    if scheduled_for <= datetime.utcnow():
+        if auto_alert is not None:
+            db.delete(auto_alert)
+            db.commit()
+        return None
+
+    if auto_alert is None:
+        auto_alert = Alert(
+            title=f"Lembrete: {event.title}",
+            message=f"O evento '{event.title}' começará em breve.",
+            scheduled_for=scheduled_for,
+            is_auto=True,
+            event_id=event.id,
+        )
+        db.add(auto_alert)
+    else:
+        auto_alert.title = f"Lembrete: {event.title}"
+        auto_alert.message = f"O evento '{event.title}' começará em breve."
+        auto_alert.scheduled_for = scheduled_for
+    db.commit()
+    db.refresh(auto_alert)
+    return auto_alert
+
+
+def create_alert(db: Session, alert_in: schemas.AlertCreate, *, creator: Optional[User] = None) -> Alert:
+    alert = Alert(**alert_in.dict(), creator_id=creator.id if creator else None)
+    db.add(alert)
+    db.commit()
+    db.refresh(alert)
+    return alert
+
+
+def mark_alert_sent(db: Session, alert: Alert) -> Alert:
+    alert.sent_at = datetime.utcnow()
+    db.add(alert)
+    db.commit()
+    db.refresh(alert)
+    return alert
+
+
+def create_confession(db: Session, confession_in: schemas.ConfessionCreate) -> ConfessionSlot:
+    slot = ConfessionSlot(**confession_in.dict())
+    db.add(slot)
+    db.commit()
+    db.refresh(slot)
+    return slot
+
+
+def delete_confession(db: Session, slot: ConfessionSlot) -> None:
+    db.delete(slot)
+    db.commit()
+
+
+def list_upcoming_alerts(db: Session) -> Iterable[Alert]:
+    return db.query(Alert).order_by(Alert.scheduled_for.asc()).all()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,25 @@
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from .config import get_settings
+
+settings = get_settings()
+engine = create_engine(settings.database_url, connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {})
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()
+
+
+@contextmanager
+def session_scope() -> Iterator[sessionmaker]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,157 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from . import crud, schemas
+from .auth import create_access_token, get_current_user, get_db, verify_password
+from .config import get_settings
+from .database import Base, SessionLocal, engine
+from .models import Alert, ConfessionSlot, Event, User
+from .notifications import init_scheduler, schedule_alert
+
+settings = get_settings()
+Base.metadata.create_all(bind=engine)
+app = FastAPI(title=settings.app_name)
+
+if settings.cors_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    init_scheduler(app)
+    if settings.admin_email and settings.admin_password:
+        with SessionLocal() as db:
+            existing = crud.get_user_by_email(db, settings.admin_email)
+            if existing is None:
+                crud.create_user(
+                    db,
+                    schemas.UserCreate(email=settings.admin_email, password=settings.admin_password),
+                )
+
+
+@app.post("/auth/login", response_model=schemas.Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = crud.get_user_by_email(db, form_data.username)
+    if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Credenciais inválidas")
+    access_token = create_access_token({"sub": user.email})
+    return schemas.Token(access_token=access_token)
+
+
+@app.post("/auth/users", response_model=schemas.UserRead)
+def create_admin_user(
+    user_in: schemas.UserCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if crud.get_user_by_email(db, user_in.email):
+        raise HTTPException(status_code=400, detail="E-mail já cadastrado")
+    user = crud.create_user(db, user_in)
+    return user
+
+
+@app.get("/public/events", response_model=List[schemas.EventRead])
+def list_events(db: Session = Depends(get_db)):
+    return db.query(Event).order_by(Event.starts_at.asc()).all()
+
+
+@app.get("/public/alerts", response_model=List[schemas.AlertRead])
+def list_alerts(db: Session = Depends(get_db)):
+    return db.query(Alert).order_by(Alert.scheduled_for.asc()).all()
+
+
+@app.get("/public/confessions", response_model=List[schemas.ConfessionRead])
+def list_confessions(db: Session = Depends(get_db)):
+    return db.query(ConfessionSlot).order_by(ConfessionSlot.starts_at.asc()).all()
+
+
+@app.post("/admin/events", response_model=schemas.EventRead)
+def create_event(
+    event_in: schemas.EventCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    event = crud.create_event(db, event_in)
+    for alert in event.alerts:
+        schedule_alert(alert)
+    return event
+
+
+@app.put("/admin/events/{event_id}", response_model=schemas.EventRead)
+def update_event(
+    event_id: int,
+    event_in: schemas.EventUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Evento não encontrado")
+    event = crud.update_event(db, event, event_in)
+    for alert in event.alerts:
+        if alert.is_auto:
+            schedule_alert(alert)
+    return event
+
+
+@app.delete("/admin/events/{event_id}", status_code=204)
+def delete_event(
+    event_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Evento não encontrado")
+    crud.delete_event(db, event)
+    return None
+
+
+@app.post("/admin/alerts", response_model=schemas.AlertRead)
+def create_alert(
+    alert_in: schemas.AlertCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    alert = crud.create_alert(db, alert_in, creator=current_user)
+    schedule_alert(alert)
+    return alert
+
+
+@app.post("/admin/confessions", response_model=schemas.ConfessionRead)
+def create_confession(
+    confession_in: schemas.ConfessionCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    slot = crud.create_confession(db, confession_in)
+    return slot
+
+
+@app.delete("/admin/confessions/{confession_id}", status_code=204)
+def delete_confession(
+    confession_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    slot = db.query(ConfessionSlot).filter(ConfessionSlot.id == confession_id).first()
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Horário não encontrado")
+    crud.delete_confession(db, slot)
+    return None
+
+
+@app.get("/health")
+def health_check() -> dict:
+    return {"status": "ok", "timestamp": datetime.utcnow()}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    alerts = relationship("Alert", back_populates="creator", cascade="all, delete-orphan")
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    speaker = Column(String(255), nullable=True)
+    location = Column(String(255), nullable=True)
+    description = Column(Text, nullable=True)
+    starts_at = Column(DateTime, nullable=False, index=True)
+    ends_at = Column(DateTime, nullable=True)
+    day_label = Column(String(50), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    alerts = relationship("Alert", back_populates="event")
+
+
+class Alert(Base):
+    __tablename__ = "alerts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    message = Column(Text, nullable=False)
+    scheduled_for = Column(DateTime, nullable=False, index=True)
+    sent_at = Column(DateTime, nullable=True)
+    is_auto = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    creator_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    event_id = Column(Integer, ForeignKey("events.id"), nullable=True)
+
+    creator = relationship("User", back_populates="alerts")
+    event = relationship("Event", back_populates="alerts")
+
+
+class ConfessionSlot(Base):
+    __tablename__ = "confession_slots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    location = Column(String(255), nullable=True)
+    starts_at = Column(DateTime, nullable=False, index=True)
+    ends_at = Column(DateTime, nullable=False)
+    priest = Column(String(255), nullable=True)
+    notes = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from typing import Optional
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.date import DateTrigger
+from fastapi import FastAPI
+from sqlalchemy.orm import Session
+
+from .crud import list_upcoming_alerts
+from .database import SessionLocal
+from .models import Alert
+
+scheduler = AsyncIOScheduler()
+
+
+def _send_alert(alert: Alert, db: Session) -> None:
+    if alert.sent_at is not None:
+        return
+    alert.sent_at = datetime.utcnow()
+    db.add(alert)
+    db.commit()
+    # Aqui ficaria a integração com FCM/APNS. Por ora registramos no log.
+    print(f"[ALERTA] {alert.title}: {alert.message} (enviado em {alert.sent_at.isoformat()} UTC)")
+
+
+def schedule_alert(alert: Alert) -> None:
+    if alert.sent_at is not None:
+        return
+    if alert.scheduled_for <= datetime.utcnow():
+        with SessionLocal() as db:
+            _send_alert(alert, db)
+        return
+
+    scheduler.add_job(
+        func=_execute_alert_job,
+        trigger=DateTrigger(run_date=alert.scheduled_for),
+        args=[alert.id],
+        id=f"alert-{alert.id}",
+        replace_existing=True,
+        misfire_grace_time=60 * 30,
+    )
+
+
+def _execute_alert_job(alert_id: int) -> None:
+    with SessionLocal() as db:
+        alert: Optional[Alert] = db.query(Alert).filter(Alert.id == alert_id).first()
+        if alert is None:
+            return
+        _send_alert(alert, db)
+
+
+def load_existing_alerts() -> None:
+    with SessionLocal() as db:
+        for alert in list_upcoming_alerts(db):
+            schedule_alert(alert)
+
+
+def init_scheduler(app: FastAPI) -> None:
+    if not scheduler.running:
+        scheduler.start()
+    load_existing_alerts()
+
+    @app.on_event("shutdown")
+    def shutdown_scheduler() -> None:  # pragma: no cover
+        if scheduler.running:
+            scheduler.shutdown()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    sub: Optional[str] = None
+
+
+class UserBase(BaseModel):
+    email: EmailStr
+
+
+class UserCreate(UserBase):
+    password: str = Field(min_length=6)
+
+
+class UserRead(UserBase):
+    id: int
+    is_active: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class EventBase(BaseModel):
+    title: str
+    speaker: Optional[str] = None
+    location: Optional[str] = None
+    description: Optional[str] = None
+    starts_at: datetime
+    ends_at: Optional[datetime] = None
+    day_label: Optional[str] = None
+
+
+class EventCreate(EventBase):
+    pass
+
+
+class EventUpdate(BaseModel):
+    title: Optional[str] = None
+    speaker: Optional[str] = None
+    location: Optional[str] = None
+    description: Optional[str] = None
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+    day_label: Optional[str] = None
+
+
+class EventRead(EventBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class AlertBase(BaseModel):
+    title: str
+    message: str
+    scheduled_for: datetime
+
+
+class AlertCreate(AlertBase):
+    event_id: Optional[int] = None
+
+
+class AlertRead(AlertBase):
+    id: int
+    sent_at: Optional[datetime] = None
+    is_auto: bool
+    event_id: Optional[int]
+
+    class Config:
+        orm_mode = True
+
+
+class ConfessionBase(BaseModel):
+    location: Optional[str] = None
+    starts_at: datetime
+    ends_at: datetime
+    priest: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class ConfessionCreate(ConfessionBase):
+    pass
+
+
+class ConfessionRead(ConfessionBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+sqlalchemy==2.0.29
+python-jose==3.3.0
+passlib[bcrypt]==1.7.4
+pydantic[email]==1.10.14
+apscheduler==3.10.4
+python-multipart==0.0.9

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Provider as PaperProvider } from "react-native-paper";
+import { NavigationContainer } from "@react-navigation/native";
+import { StatusBar } from "react-native";
+
+import { AuthProvider } from "@/context/AuthContext";
+import RootNavigator from "@/navigation/RootNavigator";
+
+export default function App() {
+  return (
+    <PaperProvider>
+      <AuthProvider>
+        <NavigationContainer>
+          <StatusBar barStyle="dark-content" />
+          <RootNavigator />
+        </NavigationContainer>
+      </AuthProvider>
+    </PaperProvider>
+  );
+}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,32 @@
+# Aplicativo móvel Seara 2026
+
+Aplicativo desenvolvido com Expo/React Native para consulta pública da programação do Seara 2026 e painel administrativo protegido por login.
+
+## Pré-requisitos
+
+- Node.js 18+
+- Expo CLI (opcional) `npm install -g expo-cli`
+
+## Configuração
+
+1. Instale dependências:
+
+```bash
+npm install
+```
+
+2. Configure a URL da API FastAPI:
+   - Por padrão o app usa `http://localhost:8000`.
+   - Para customizar, crie um arquivo `.env` com `EXPO_PUBLIC_API_URL=http://seu-servidor:8000`.
+
+3. Inicie o projeto:
+
+```bash
+npm run start
+```
+
+Use o Expo Go ou emuladores Android/iOS para testar. O painel administrativo fica na aba "Admin" e requer login válido (credenciais gerenciadas pela API).
+
+## Build para lojas
+
+Siga a documentação do [Expo Application Services](https://docs.expo.dev/eas/) para gerar binários assinados com os identificadores definidos em `app.json`.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,30 @@
+{
+  "expo": {
+    "name": "Seara 2026",
+    "slug": "seara2026",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "com.seara2026.app"
+    },
+    "android": {
+      "package": "com.seara2026.app",
+      "versionCode": 1
+    },
+    "web": {
+      "bundler": "metro"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,17 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      [
+        "module-resolver",
+        {
+          extensions: [".ts", ".tsx", ".js", ".json"],
+          alias: {
+            "@": "./src"
+          }
+        }
+      ]
+    ]
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "seara2026",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.17",
+    "axios": "^1.6.8",
+    "expo": "^51.0.3",
+    "expo-secure-store": "^12.8.1",
+    "react": "18.2.0",
+    "react-native": "0.74.1",
+    "react-native-safe-area-context": "^4.9.0",
+    "react-native-screens": "^3.30.1",
+    "react-native-paper": "^5.12.5",
+    "dayjs": "^1.11.10"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.3",
+    "@types/react": "18.2.21",
+    "@types/react-native": "0.73.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000",
+});
+
+export default api;

--- a/mobile/src/components/AlertForm.tsx
+++ b/mobile/src/components/AlertForm.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Button, HelperText, TextInput } from "react-native-paper";
+
+interface Props {
+  onSubmit: (payload: { title: string; message: string; scheduled_for: string; event_id?: number }) => Promise<void>;
+}
+
+const AlertForm: React.FC<Props> = ({ onSubmit }) => {
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [eventId, setEventId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!title || !message || !scheduledFor) {
+      setError("Todos os campos obrigatórios precisam ser preenchidos");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await onSubmit({
+        title,
+        message,
+        scheduled_for: scheduledFor,
+        event_id: eventId ? Number(eventId) : undefined,
+      });
+      setTitle("");
+      setMessage("");
+      setScheduledFor("");
+      setEventId("");
+    } catch (e) {
+      setError("Não foi possível salvar o alerta");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput label="Título" value={title} onChangeText={setTitle} style={styles.input} />
+      <TextInput
+        label="Mensagem"
+        value={message}
+        onChangeText={setMessage}
+        style={styles.input}
+        multiline
+      />
+      <TextInput
+        label="Agendar para (ISO)"
+        value={scheduledFor}
+        onChangeText={setScheduledFor}
+        style={styles.input}
+      />
+      <TextInput
+        label="Evento relacionado (ID opcional)"
+        value={eventId}
+        onChangeText={setEventId}
+        style={styles.input}
+        keyboardType="numeric"
+      />
+      {error && <HelperText type="error">{error}</HelperText>}
+      <Button mode="contained" onPress={handleSubmit} loading={loading}>
+        Salvar alerta
+      </Button>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  input: {
+    backgroundColor: "transparent",
+  },
+});
+
+export default AlertForm;

--- a/mobile/src/components/ConfessionForm.tsx
+++ b/mobile/src/components/ConfessionForm.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Button, HelperText, TextInput } from "react-native-paper";
+
+interface Props {
+  onSubmit: (payload: {
+    location?: string;
+    starts_at: string;
+    ends_at: string;
+    priest?: string;
+    notes?: string;
+  }) => Promise<void>;
+}
+
+const ConfessionForm: React.FC<Props> = ({ onSubmit }) => {
+  const [location, setLocation] = useState("");
+  const [startsAt, setStartsAt] = useState("");
+  const [endsAt, setEndsAt] = useState("");
+  const [priest, setPriest] = useState("");
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!startsAt || !endsAt) {
+      setError("Início e fim são obrigatórios");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await onSubmit({
+        location: location || undefined,
+        starts_at: startsAt,
+        ends_at: endsAt,
+        priest: priest || undefined,
+        notes: notes || undefined,
+      });
+      setLocation("");
+      setStartsAt("");
+      setEndsAt("");
+      setPriest("");
+      setNotes("");
+    } catch (e) {
+      setError("Não foi possível salvar o horário");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput label="Local" value={location} onChangeText={setLocation} style={styles.input} />
+      <TextInput
+        label="Início (ISO)"
+        value={startsAt}
+        onChangeText={setStartsAt}
+        style={styles.input}
+      />
+      <TextInput label="Fim (ISO)" value={endsAt} onChangeText={setEndsAt} style={styles.input} />
+      <TextInput label="Sacerdote" value={priest} onChangeText={setPriest} style={styles.input} />
+      <TextInput label="Observações" value={notes} onChangeText={setNotes} style={styles.input} multiline />
+      {error && <HelperText type="error">{error}</HelperText>}
+      <Button mode="contained" onPress={handleSubmit} loading={loading}>
+        Salvar horário
+      </Button>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  input: {
+    backgroundColor: "transparent",
+  },
+});
+
+export default ConfessionForm;

--- a/mobile/src/components/EventForm.tsx
+++ b/mobile/src/components/EventForm.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Button, HelperText, TextInput } from "react-native-paper";
+
+interface Props {
+  onSubmit: (payload: {
+    title: string;
+    speaker?: string;
+    location?: string;
+    description?: string;
+    starts_at: string;
+    ends_at?: string;
+    day_label?: string;
+  }) => Promise<void>;
+}
+
+const EventForm: React.FC<Props> = ({ onSubmit }) => {
+  const [title, setTitle] = useState("");
+  const [speaker, setSpeaker] = useState("");
+  const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [startsAt, setStartsAt] = useState("");
+  const [endsAt, setEndsAt] = useState("");
+  const [dayLabel, setDayLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!title || !startsAt) {
+      setError("Título e início são obrigatórios");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await onSubmit({
+        title,
+        speaker: speaker || undefined,
+        location: location || undefined,
+        description: description || undefined,
+        starts_at: startsAt,
+        ends_at: endsAt || undefined,
+        day_label: dayLabel || undefined,
+      });
+      setTitle("");
+      setSpeaker("");
+      setLocation("");
+      setDescription("");
+      setStartsAt("");
+      setEndsAt("");
+      setDayLabel("");
+    } catch (e) {
+      setError("Não foi possível salvar o evento");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput label="Título" value={title} onChangeText={setTitle} style={styles.input} />
+      <TextInput label="Pregador" value={speaker} onChangeText={setSpeaker} style={styles.input} />
+      <TextInput label="Local" value={location} onChangeText={setLocation} style={styles.input} />
+      <TextInput
+        label="Descrição"
+        value={description}
+        onChangeText={setDescription}
+        style={styles.input}
+        multiline
+      />
+      <TextInput
+        label="Início (ISO ex: 2025-09-27T17:00:00)"
+        value={startsAt}
+        onChangeText={setStartsAt}
+        style={styles.input}
+      />
+      <TextInput
+        label="Fim (opcional)"
+        value={endsAt}
+        onChangeText={setEndsAt}
+        style={styles.input}
+      />
+      <TextInput label="Dia" value={dayLabel} onChangeText={setDayLabel} style={styles.input} />
+      {error && <HelperText type="error">{error}</HelperText>}
+      <Button mode="contained" onPress={handleSubmit} loading={loading}>
+        Salvar evento
+      </Button>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  input: {
+    backgroundColor: "transparent",
+  },
+});
+
+export default EventForm;

--- a/mobile/src/context/AuthContext.tsx
+++ b/mobile/src/context/AuthContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import * as SecureStore from "expo-secure-store";
+import api from "@/api/client";
+
+interface AuthContextValue {
+  token: string | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const storedToken = await SecureStore.getItemAsync("token");
+      if (storedToken) {
+        setToken(storedToken);
+        api.defaults.headers.common.Authorization = `Bearer ${storedToken}`;
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const body = `username=${encodeURIComponent(email)}&password=${encodeURIComponent(password)}`;
+
+    const response = await api.post("/auth/login", body, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    const accessToken: string = response.data.access_token;
+    setToken(accessToken);
+    api.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+    await SecureStore.setItemAsync("token", accessToken);
+  };
+
+  const logout = async () => {
+    setToken(null);
+    delete api.defaults.headers.common.Authorization;
+    await SecureStore.deleteItemAsync("token");
+  };
+
+  const value = useMemo(
+    () => ({ token, loading, login, logout }),
+    [token, loading]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth deve ser usado dentro de AuthProvider");
+  }
+  return context;
+};

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import LoginScreen from "@/screens/LoginScreen";
+import TabsNavigator from "@/navigation/TabsNavigator";
+import { useAuth } from "@/context/AuthContext";
+
+export type RootStackParamList = {
+  Login: undefined;
+  App: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const RootNavigator: React.FC = () => {
+  const { token, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      {token ? (
+        <Stack.Screen name="App" component={TabsNavigator} />
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} />
+      )}
+    </Stack.Navigator>
+  );
+};
+
+export default RootNavigator;

--- a/mobile/src/navigation/TabsNavigator.tsx
+++ b/mobile/src/navigation/TabsNavigator.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+import ScheduleScreen from "@/screens/ScheduleScreen";
+import ConfessionScreen from "@/screens/ConfessionScreen";
+import AlertsScreen from "@/screens/AlertsScreen";
+import AdminDashboard from "@/screens/Admin/Dashboard";
+
+export type TabParamList = {
+  Programacao: undefined;
+  Alertas: undefined;
+  Confissoes: undefined;
+  Admin: undefined;
+};
+
+const Tabs = createBottomTabNavigator<TabParamList>();
+
+const TabsNavigator: React.FC = () => (
+  <Tabs.Navigator
+    screenOptions={({ route }) => ({
+      headerShown: false,
+      tabBarIcon: ({ color, size }) => {
+        let iconName: React.ComponentProps<typeof MaterialCommunityIcons>["name"] = "calendar";
+        if (route.name === "Alertas") iconName = "bell";
+        if (route.name === "Confissoes") iconName = "church";
+        if (route.name === "Admin") iconName = "shield-account";
+        return <MaterialCommunityIcons name={iconName} color={color} size={size} />;
+      },
+    })}
+  >
+    <Tabs.Screen name="Programacao" component={ScheduleScreen} options={{ title: "Programação" }} />
+    <Tabs.Screen name="Alertas" component={AlertsScreen} />
+    <Tabs.Screen name="Confissoes" component={ConfessionScreen} options={{ title: "Confissões" }} />
+    <Tabs.Screen name="Admin" component={AdminDashboard} />
+  </Tabs.Navigator>
+);
+
+export default TabsNavigator;

--- a/mobile/src/screens/Admin/Dashboard.tsx
+++ b/mobile/src/screens/Admin/Dashboard.tsx
@@ -1,0 +1,168 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button, Card, Divider, IconButton, List, Text } from "react-native-paper";
+
+import api from "@/api/client";
+import EventForm from "@/components/EventForm";
+import AlertForm from "@/components/AlertForm";
+import ConfessionForm from "@/components/ConfessionForm";
+import { useAuth } from "@/context/AuthContext";
+import { ConfessionSlot, Event, SearaAlert } from "@/types";
+
+const AdminDashboard: React.FC = () => {
+  const { logout } = useAuth();
+  const [events, setEvents] = useState<Event[]>([]);
+  const [alerts, setAlerts] = useState<SearaAlert[]>([]);
+  const [confessions, setConfessions] = useState<ConfessionSlot[]>([]);
+
+  const loadData = useCallback(async () => {
+    const [eventRes, alertRes, confessionRes] = await Promise.all([
+      api.get<Event[]>("/public/events"),
+      api.get<SearaAlert[]>("/public/alerts"),
+      api.get<ConfessionSlot[]>("/public/confessions"),
+    ]);
+    setEvents(eventRes.data);
+    setAlerts(alertRes.data);
+    setConfessions(confessionRes.data);
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleCreateEvent = async (payload: {
+    title: string;
+    speaker?: string;
+    location?: string;
+    description?: string;
+    starts_at: string;
+    ends_at?: string;
+    day_label?: string;
+  }) => {
+    await api.post("/admin/events", payload);
+    await loadData();
+  };
+
+  const handleCreateAlert = async (payload: {
+    title: string;
+    message: string;
+    scheduled_for: string;
+    event_id?: number;
+  }) => {
+    await api.post("/admin/alerts", payload);
+    await loadData();
+  };
+
+  const handleCreateConfession = async (payload: {
+    location?: string;
+    starts_at: string;
+    ends_at: string;
+    priest?: string;
+    notes?: string;
+  }) => {
+    await api.post("/admin/confessions", payload);
+    await loadData();
+  };
+
+  const handleDeleteConfession = async (id: number) => {
+    await api.delete(`/admin/confessions/${id}`);
+    await loadData();
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.header}>
+        <Text variant="headlineSmall">Painel administrativo</Text>
+        <Button mode="outlined" onPress={logout}>
+          Sair
+        </Button>
+      </View>
+
+      <Card style={styles.card}>
+        <Card.Title title="Cadastrar evento" />
+        <Card.Content>
+          <EventForm onSubmit={handleCreateEvent} />
+        </Card.Content>
+      </Card>
+
+      <Card style={styles.card}>
+        <Card.Title title="Cadastrar alerta manual" />
+        <Card.Content>
+          <AlertForm onSubmit={handleCreateAlert} />
+        </Card.Content>
+      </Card>
+
+      <Card style={styles.card}>
+        <Card.Title title="Cadastrar horário de confissão" />
+        <Card.Content>
+          <ConfessionForm onSubmit={handleCreateConfession} />
+        </Card.Content>
+      </Card>
+
+      <List.Section>
+        <List.Subheader>Eventos cadastrados</List.Subheader>
+        {events.map((event) => (
+          <List.Item
+            key={event.id}
+            title={event.title}
+            description={`${event.speaker ?? ""} - ${event.starts_at}`}
+            left={(props) => <List.Icon {...props} icon="calendar" />}
+          />
+        ))}
+        {events.length === 0 && <Text>Nenhum evento cadastrado.</Text>}
+      </List.Section>
+
+      <Divider />
+
+      <List.Section>
+        <List.Subheader>Alertas cadastrados</List.Subheader>
+        {alerts.map((alert) => (
+          <List.Item
+            key={alert.id}
+            title={alert.title}
+            description={`${alert.scheduled_for} - ${alert.is_auto ? "Automático" : "Manual"}`}
+            left={(props) => <List.Icon {...props} icon="bell" />}
+          />
+        ))}
+        {alerts.length === 0 && <Text>Nenhum alerta cadastrado.</Text>}
+      </List.Section>
+
+      <Divider />
+
+      <List.Section>
+        <List.Subheader>Confissões</List.Subheader>
+        {confessions.map((confession) => (
+          <List.Item
+            key={confession.id}
+            title={confession.location ?? "Confissão"}
+            description={`${confession.starts_at} - ${confession.ends_at}`}
+            left={(props) => <List.Icon {...props} icon="church" />}
+            right={() => (
+              <IconButton icon="delete" onPress={() => handleDeleteConfession(confession.id)} />
+            )}
+          />
+        ))}
+        {confessions.length === 0 && <Text>Nenhum horário cadastrado.</Text>}
+      </List.Section>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 16,
+    backgroundColor: "#f5f5f5",
+  },
+  card: {
+    marginBottom: 16,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+});
+
+export default AdminDashboard;

--- a/mobile/src/screens/AlertsScreen.tsx
+++ b/mobile/src/screens/AlertsScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from "react";
+import { FlatList, RefreshControl, StyleSheet, View } from "react-native";
+import { Card, Text } from "react-native-paper";
+import dayjs from "dayjs";
+import "dayjs/locale/pt-br";
+
+import api from "@/api/client";
+import { SearaAlert } from "@/types";
+
+dayjs.locale("pt-br");
+
+const AlertsScreen: React.FC = () => {
+  const [alerts, setAlerts] = useState<SearaAlert[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadAlerts = async () => {
+    setRefreshing(true);
+    try {
+      const response = await api.get<SearaAlert[]>("/public/alerts");
+      setAlerts(response.data);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    loadAlerts();
+  }, []);
+
+  return (
+    <FlatList
+      data={alerts}
+      keyExtractor={(item) => item.id.toString()}
+      contentContainerStyle={styles.list}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadAlerts} />}
+      renderItem={({ item }) => (
+        <Card style={styles.card}>
+          <Card.Title title={item.title} />
+          <Card.Content>
+            <Text>{item.message}</Text>
+            <Text>Agendado para: {dayjs(item.scheduled_for).format("DD/MM/YYYY HH:mm")}</Text>
+            {item.sent_at && <Text>Enviado em: {dayjs(item.sent_at).format("DD/MM/YYYY HH:mm")}</Text>}
+            <Text>Tipo: {item.is_auto ? "Automático" : "Manual"}</Text>
+          </Card.Content>
+        </Card>
+      )}
+      ListEmptyComponent={() => (
+        <View style={styles.emptyContainer}>
+          <Text>Nenhum alerta cadastrado.</Text>
+        </View>
+      )}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  list: {
+    padding: 16,
+    gap: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 64,
+  },
+});
+
+export default AlertsScreen;

--- a/mobile/src/screens/ConfessionScreen.tsx
+++ b/mobile/src/screens/ConfessionScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from "react";
+import { FlatList, RefreshControl, StyleSheet, View } from "react-native";
+import { Card, Text } from "react-native-paper";
+import dayjs from "dayjs";
+import "dayjs/locale/pt-br";
+
+import api from "@/api/client";
+import { ConfessionSlot } from "@/types";
+
+dayjs.locale("pt-br");
+
+const ConfessionScreen: React.FC = () => {
+  const [slots, setSlots] = useState<ConfessionSlot[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadSlots = async () => {
+    setRefreshing(true);
+    try {
+      const response = await api.get<ConfessionSlot[]>("/public/confessions");
+      setSlots(response.data);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSlots();
+  }, []);
+
+  return (
+    <FlatList
+      data={slots}
+      keyExtractor={(item) => item.id.toString()}
+      contentContainerStyle={styles.list}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadSlots} />}
+      renderItem={({ item }) => (
+        <Card style={styles.card}>
+          <Card.Title title={item.location ?? "Confissão"} subtitle={item.priest ?? undefined} />
+          <Card.Content>
+            <Text>
+              {dayjs(item.starts_at).format("DD/MM/YYYY HH:mm")} - {dayjs(item.ends_at).format("HH:mm")}
+            </Text>
+            {item.notes && <Text>{item.notes}</Text>}
+          </Card.Content>
+        </Card>
+      )}
+      ListEmptyComponent={() => (
+        <View style={styles.emptyContainer}>
+          <Text>Nenhum horário cadastrado.</Text>
+        </View>
+      )}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  list: {
+    padding: 16,
+    gap: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 64,
+  },
+});
+
+export default ConfessionScreen;

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { View, StyleSheet } from "react-native";
+import { Button, HelperText, Text, TextInput } from "react-native-paper";
+
+import { useAuth } from "@/context/AuthContext";
+
+const LoginScreen: React.FC = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      await login(email, password);
+    } catch (err) {
+      setError("Falha ao entrar. Verifique suas credenciais.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text variant="headlineSmall" style={styles.title}>
+        Acesso administrativo
+      </Text>
+      <TextInput
+        label="E-mail"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
+        style={styles.input}
+      />
+      <TextInput
+        label="Senha"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      {error && <HelperText type="error">{error}</HelperText>}
+      <Button mode="contained" onPress={handleLogin} loading={loading} disabled={loading}>
+        Entrar
+      </Button>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    padding: 24,
+    backgroundColor: "#fff",
+  },
+  title: {
+    marginBottom: 24,
+    textAlign: "center",
+  },
+  input: {
+    marginBottom: 16,
+  },
+});
+
+export default LoginScreen;

--- a/mobile/src/screens/ScheduleScreen.tsx
+++ b/mobile/src/screens/ScheduleScreen.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import { View, FlatList, RefreshControl, StyleSheet } from "react-native";
+import { Card, Text } from "react-native-paper";
+import dayjs from "dayjs";
+import "dayjs/locale/pt-br";
+
+import api from "@/api/client";
+import { Event } from "@/types";
+
+dayjs.locale("pt-br");
+
+const ScheduleScreen: React.FC = () => {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadEvents = async () => {
+    setRefreshing(true);
+    try {
+      const response = await api.get<Event[]>("/public/events");
+      setEvents(response.data);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    loadEvents();
+  }, []);
+
+  return (
+    <FlatList
+      data={events}
+      keyExtractor={(item) => item.id.toString()}
+      contentContainerStyle={styles.list}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadEvents} />}
+      renderItem={({ item }) => (
+        <Card style={styles.card}>
+          <Card.Title title={item.title} subtitle={item.speaker ?? undefined} />
+          <Card.Content>
+            <Text>{dayjs(item.starts_at).format("dddd, DD/MM/YYYY HH:mm")}</Text>
+            {item.location && <Text>Local: {item.location}</Text>}
+            {item.description && <Text>{item.description}</Text>}
+          </Card.Content>
+        </Card>
+      )}
+      ListEmptyComponent={() => (
+        <View style={styles.emptyContainer}>
+          <Text>Nenhum evento cadastrado ainda.</Text>
+        </View>
+      )}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  list: {
+    padding: 16,
+    gap: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 64,
+  },
+});
+
+export default ScheduleScreen;

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -1,0 +1,29 @@
+export interface Event {
+  id: number;
+  title: string;
+  speaker?: string | null;
+  location?: string | null;
+  description?: string | null;
+  starts_at: string;
+  ends_at?: string | null;
+  day_label?: string | null;
+}
+
+export interface SearaAlert {
+  id: number;
+  title: string;
+  message: string;
+  scheduled_for: string;
+  sent_at?: string | null;
+  is_auto: boolean;
+  event_id?: number | null;
+}
+
+export interface ConfessionSlot {
+  id: number;
+  location?: string | null;
+  starts_at: string;
+  ends_at: string;
+  priest?: string | null;
+  notes?: string | null;
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/api/*": ["src/api/*"],
+      "@/components/*": ["src/components/*"],
+      "@/context/*": ["src/context/*"],
+      "@/screens/*": ["src/screens/*"],
+      "@/navigation/*": ["src/navigation/*"]
+    },
+    "types": ["react", "react-native", "jest"],
+    "skipLibCheck": true
+  },
+  "include": ["src", "App.tsx"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+}


### PR DESCRIPTION
## Summary
- create FastAPI backend with JWT authentication, event scheduling, alerts, and confession endpoints
- add automatic 10 minute reminders and manual alert scheduling backed by APScheduler
- scaffold Expo mobile app with public schedule/confession views and an admin panel for managing data

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d8174a697c8330bc9fcdacbcd6ec6b